### PR TITLE
Remove unused pages

### DIFF
--- a/app/posts/proc-ops/2019-12-31-example-post.md
+++ b/app/posts/proc-ops/2019-12-31-example-post.md
@@ -1,7 +1,0 @@
----
-title: Holding page
-description: description here
-date: 2019-12-31
----
-
-This is a holding post

--- a/app/posts/proc-ops/proc-ops.json
+++ b/app/posts/proc-ops/proc-ops.json
@@ -1,6 +1,0 @@
-{
-    "tags": ["proc-ops"],
-    "eleventyNavigation": {
-      "parent": "Proc ops"
-    }
-  }

--- a/app/posts/specify/2019-12-31-example-post.md
+++ b/app/posts/specify/2019-12-31-example-post.md
@@ -1,7 +1,0 @@
----
-title: Holding page
-description: description here
-date: 2019-12-31
----
-
-This is a holding post

--- a/app/posts/specify/specify.json
+++ b/app/posts/specify/specify.json
@@ -1,6 +1,0 @@
-{
-    "tags": ["specify"],
-    "eleventyNavigation": {
-      "parent": "Specify"
-    }
-  }


### PR DESCRIPTION
Procurement operations and specify holding pages
have been removed. We will add in new sections as
and when we need then.